### PR TITLE
Fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "babel-runtime": "^5.5.8",
     "lacona-phrase": "^0.7.0",
-    "lodash": "^3.9.3"
+    "lodash": "^3.9.3",
+    "smart-split": "^1.0.2"
   }
 }


### PR DESCRIPTION
Added the smart-split library which was referenced but not included.

I noticed a lot of changes from lacona 0.27.0 on npm. It might also make sense to do a version bump.